### PR TITLE
fixed configuration NOTHREADS

### DIFF
--- a/ntlmaps/config_affairs.py
+++ b/ntlmaps/config_affairs.py
@@ -98,6 +98,7 @@ def arrange(conf):
     conf['DEBUG']['DEBUG'] = makeInt(conf['DEBUG']['DEBUG'], 'DEBUG')
     conf['DEBUG']['AUTH_DEBUG'] = makeInt(conf['DEBUG']['AUTH_DEBUG'], 'AUTH_DEBUG')
     conf['DEBUG']['BIN_DEBUG'] = makeInt(conf['DEBUG']['BIN_DEBUG'], 'BIN_DEBUG')
+    conf['DEBUG']['NOTHREADS'] = makeInt(conf['DEBUG']['NOTHREADS'], 'NOTHREADS')
 
     # screen activity
     if conf['DEBUG'].has_key('SCR_DEBUG'):


### PR DESCRIPTION
Without this fix even NOTHREADS: 0 in server.cfg, self.config['DEBUG'].get('NOTHREADS') returns '0' (string), therefore true ...
